### PR TITLE
Provide repo with org.w3c dependencies of batik

### DIFF
--- a/simrel.aggr
+++ b/simrel.aggr
@@ -2,9 +2,15 @@
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Aggregation files used for Simultaneous Release (quarterly &quot;release train&quot;)." buildmaster="//@contacts[email='ed.merks@gmail.com']" buildmasterBackup="//@contacts[email='frederic.gurr@eclipse.org']" label="2023-12" buildRoot="buildresults" packedStrategy="UNPACK_AS_SIBLING" sendmail="true" type="I" allowLegacySites="false">
   <validationSets label="main">
     <contributions label="Orbit-CVS-Legacy-To-Be-Deleted">
-      <repositories location="https://download.eclipse.org/tools/orbit/downloads/drops/R20201118194144/repository">
-        <bundles name="org.w3c.css.sac"/>
-        <bundles name="org.w3c.dom.svg"/>
+      <repositories location="https://download.eclipse.org/oomph/simrel-extras/release/1.1.0">
+        <bundles name="org.w3c.css.sac" versionRange="[1.3.1.v200903091627]"/>
+        <bundles name="org.w3c.css.sac.source" versionRange="[1.3.1.v200903091627]"/>
+        <bundles name="org.w3c.dom.events" versionRange="[3.0.0.draft20060413_v201105210656]"/>
+        <bundles name="org.w3c.dom.events.source" versionRange="[3.0.0.draft20060413_v201105210656]"/>
+        <bundles name="org.w3c.dom.smil" versionRange="[1.0.1.v200903091627]"/>
+        <bundles name="org.w3c.dom.smil.source" versionRange="[1.0.1.v200903091627]"/>
+        <bundles name="org.w3c.dom.svg" versionRange="[1.1.0.v201011041433]"/>
+        <bundles name="org.w3c.dom.svg.source" versionRange="[1.1.0.v201011041433]"/>
       </repositories>
     </contributions>
     <contributions href="ep.aggrcon#/"/>

--- a/simrel.aggran
+++ b/simrel.aggran
@@ -13,6 +13,9 @@
   <levels>7</levels>
   <levels>4</levels>
   <contribution
+      label="a-Orbit-CVS-Legacy-To-Be-Deleted"
+      contribution="simrel.aggr#//@validationSets[label='main']/@contributions[label='Orbit-CVS-Legacy-To-Be-Deleted']"/>
+  <contribution
       label="a.jre"
       dominant="true"
       match="a\.jre.*"/>
@@ -1143,7 +1146,4 @@
           uri="https://github.com/eclipse-tycho/tycho"/>
     </project>
   </contribution>
-  <contribution
-      label="z-Orbit-CVS-Legacy-To-Be-Deleted"
-      contribution="simrel.aggr#//@validationSets[label='main']/@contributions[label='Orbit-CVS-Legacy-To-Be-Deleted']"/>
 </analyzer:Analysis>


### PR DESCRIPTION
These dependencies were coming from the Platform repository but are collectively replaced by org.eclipse.orbit.xml-apis-ext bundle now.