### PR TITLE
Add javax annotations providing jakarta bundles

### DIFF
--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -5,6 +5,8 @@
     <products name="org.eclipse.platform.ide"/>
     <bundles name="org.eclipse.e4.ui.progress"/>
     <bundles name="org.eclipse.e4.ui.progress.source"/>
+    <bundles name="jakarta.inject.jakarta.inject-api" versionRange="[1.0.0,2.0.0)"/>
+    <bundles name="jakarta.annotation-api" versionRange="[1.0.0,2.0.0)"/>
     <features name="org.eclipse.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>


### PR DESCRIPTION
Those bundles are mentioned in the N&N entry in https://github.com/eclipse-platform/www.eclipse.org-eclipse/pull/85 and are in general the more recent original versions from Maven-Central and are not the `javax.*` once originating from old Orbit.
Therefore they should be available in the SimRel repository.

The Orbit based bundles are pulled in because they are required/included by some bundles:
![grafik](https://github.com/eclipse-simrel/simrel.build/assets/44067969/8bbba613-e3c6-4403-bf8f-c629c86a5194)

I'll check if they are already there and if not yet done will provide PRs to replace them by Import-Package imports.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056
