### PR TITLE
Include ecf.filetransfer.httpclient5 in SimRel

### DIFF
--- a/ecf.aggrcon
+++ b/ecf.aggrcon
@@ -17,6 +17,10 @@
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
     </features>
+    <features name="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" versionRange="[1.1.702.v20231021-2127]">
+      <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
+      <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
+    </features>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='slewis@composent.com']"/>
 </aggregator:Contribution>

--- a/simrel.aggr
+++ b/simrel.aggr
@@ -147,6 +147,7 @@
     <features href="egit.aggrcon#//@repositories.0/@features.10"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
+    <features href="ecf.aggrcon#//@repositories.0/@features.4"/>
   </customCategories>
   <customCategories identifier="Database Development" label="Database Development" description="Tools to define and access a wide variety of databases.">
     <features href="dtp.aggrcon#//@repositories.0/@features.0"/>
@@ -203,6 +204,7 @@
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.1"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
+    <features href="ecf.aggrcon#//@repositories.0/@features.4"/>
   </customCategories>
   <customCategories identifier="General Purpose Tools" label="General Purpose Tools" description="Tools that can be used by a wide variety of developers.">
     <features href="ep.aggrcon#//@repositories.0/@features.2"/>


### PR DESCRIPTION
This is to workaround:

- https://github.com/eclipse-equinox/p2/issues/381

And to enable:

- https://github.com/eclipse-packaging/packages/issues/81

in 2023-12 M3.

The Eclipse Platform is expected to contribute this for RC1 but including this from ECF allows us to start testing this in 2023-12 M3