### PR TITLE
Update ECF to latest 3.14.40 snapshot

### DIFF
--- a/ecf.aggrcon
+++ b/ecf.aggrcon
@@ -1,23 +1,15 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="ECF">
-  <repositories location="https://download.eclipse.org/rt/ecf/snapshot/site.p2/3.14.40.v20231021-2127" description="ECF updates">
+  <repositories location="https://download.eclipse.org/rt/ecf/snapshot/site.p2/3.14.40.v20231114-1017" description="ECF updates">
     <features name="org.eclipse.ecf.core.feature.group" versionRange="[3.14.40.v20231021-2050]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
     </features>
-    <features name="org.eclipse.ecf.core.source.feature.group" versionRange="[3.14.40.v20231021-2050]">
+    <features name="org.eclipse.ecf.remoteservice.sdk.feature.feature.group" versionRange="[3.14.40.v20231114-1017]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
     </features>
-    <features name="org.eclipse.ecf.remoteservice.sdk.feature.feature.group" versionRange="[3.14.40.v20231021-2127]">
-      <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
-      <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
-    </features>
-    <features name="org.eclipse.ecf.remoteservice.sdk.feature.source.feature.group" versionRange="[3.14.40.v20231021-2127]">
-      <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
-      <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
-    </features>
-    <features name="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" versionRange="[1.1.702.v20231021-2127]">
+    <features name="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" versionRange="[1.1.702.v20231114-1017]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
     </features>

--- a/simrel.aggr
+++ b/simrel.aggr
@@ -133,8 +133,6 @@
     <features href="mylyn-docs.aggrcon#//@repositories.0/@features.0"/>
     <features href="ecf.aggrcon#//@repositories.0/@features.0"/>
     <features href="ecf.aggrcon#//@repositories.0/@features.1"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.2"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.3"/>
     <features href="egit.aggrcon#//@repositories.0/@features.2"/>
     <features href="dltk.aggrcon#//@repositories.0/@features.4"/>
     <features href="pdt.aggrcon#//@repositories.0/@features.2"/>
@@ -147,7 +145,7 @@
     <features href="egit.aggrcon#//@repositories.0/@features.10"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.4"/>
+    <features href="ecf.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>
   <customCategories identifier="Database Development" label="Database Development" description="Tools to define and access a wide variety of databases.">
     <features href="dtp.aggrcon#//@repositories.0/@features.0"/>
@@ -192,8 +190,6 @@
     <features href="ep.aggrcon#//@repositories.0/@features.10"/>
     <features href="ecf.aggrcon#//@repositories.0/@features.0"/>
     <features href="ecf.aggrcon#//@repositories.0/@features.1"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.2"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.3"/>
     <features href="rap.aggrcon#//@repositories.0/@features.0"/>
     <features href="rap.aggrcon#//@repositories.0/@features.1"/>
     <features href="rap.aggrcon#//@repositories.0/@features.2"/>
@@ -204,7 +200,7 @@
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.1"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.4"/>
+    <features href="ecf.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>
   <customCategories identifier="General Purpose Tools" label="General Purpose Tools" description="Tools that can be used by a wide variety of developers.">
     <features href="ep.aggrcon#//@repositories.0/@features.2"/>


### PR DESCRIPTION
Remove source features because the aggregator automatically includes corresponding source bundles and features for any otherwise included bundle or feature.