### PR TITLE
Remove tycho-snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,6 @@
     <cbi.analyzers.repo.url>${download.eclipse.org}/cbi/updates/p2-analyzers/products/nightly/latest</cbi.analyzers.repo.url>
     <simrel.aggregator.build.type>CLEAN_BUILD</simrel.aggregator.build.type>
   </properties>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>tycho-snapshots</id>
-      <url>https://repo.eclipse.org/content/repositories/tycho-snapshots</url>
-    </pluginRepository>
-  </pluginRepositories>
   <profiles>
     <profile>
       <id>build</id>


### PR DESCRIPTION
It's not needed and this build should practically never have the need to use Tycho snapshots.
Removing this fixes dependabot as without it it properly updated Tycho version (https://github.com/akurtakov/simrel.build/pull/1 )