### PR TITLE
Remove ECF's httpclient5 explicit feature include

### DIFF
--- a/ecf.aggrcon
+++ b/ecf.aggrcon
@@ -9,10 +9,6 @@
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
     </features>
-    <features name="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" versionRange="[1.1.702.v20231114-1017]">
-      <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
-      <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
-    </features>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='slewis@composent.com']"/>
 </aggregator:Contribution>

--- a/simrel.aggr
+++ b/simrel.aggr
@@ -145,7 +145,6 @@
     <features href="egit.aggrcon#//@repositories.0/@features.10"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>
   <customCategories identifier="Database Development" label="Database Development" description="Tools to define and access a wide variety of databases.">
     <features href="dtp.aggrcon#//@repositories.0/@features.0"/>
@@ -200,7 +199,6 @@
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.1"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>
   <customCategories identifier="General Purpose Tools" label="General Purpose Tools" description="Tools that can be used by a wide variety of developers.">
     <features href="ep.aggrcon#//@repositories.0/@features.2"/>


### PR DESCRIPTION
This was added as a workaround and keeping it would make it more difficult to align the version required by the platform and that provided by ECF.