### PR TITLE
Use release instead of milestone URL for WindowBuilder 1.14.0

### DIFF
--- a/windowbuilder.aggrcon
+++ b/windowbuilder.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Window Builder GUI Designer" label="Window Builder">
-  <repositories location="https://download.eclipse.org/windowbuilder/updates/milestone/S202311270647" description="WindowBuilder 1.14.0">
+  <repositories location="https://download.eclipse.org/windowbuilder/updates/release/1.14.0" description="WindowBuilder 1.14.0">
     <features name="org.eclipse.wb.core.feature.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>


### PR DESCRIPTION
The milestone URL will become invalid, once the upcoming M1 is built.