### PR TITLE
Sirius Desktop 7.4.0M1

### DIFF
--- a/simrel.aggr
+++ b/simrel.aggr
@@ -333,15 +333,15 @@
     <features href="qvtd.aggrcon#//@repositories.0/@features.0"/>
     <features href="ecp.aggrcon#//@repositories.0/@features.0"/>
     <features href="sirius.aggrcon#//@repositories.0/@features.0"/>
-    <features href="sirius.aggrcon#//@repositories.0/@features.3"/>
+    <features href="sirius.aggrcon#//@repositories.0/@features.2"/>
     <features href="emf-parsley.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-parsley.aggrcon#//@repositories.0/@features.1"/>
     <features href="emf-parsley.aggrcon#//@repositories.0/@features.2"/>
     <features href="emf-parsley.aggrcon#//@repositories.0/@features.3"/>
     <features href="emf-compare.aggrcon#//@repositories.0/@features.8"/>
     <features href="emf-compare.aggrcon#//@repositories.0/@features.10"/>
+    <features href="sirius.aggrcon#//@repositories.0/@features.6"/>
     <features href="sirius.aggrcon#//@repositories.0/@features.7"/>
-    <features href="sirius.aggrcon#//@repositories.0/@features.8"/>
     <features href="viatra.aggrcon#//@repositories.0/@features.0"/>
     <features href="gmp-graphiti.aggrcon#//@repositories.0/@features.1"/>
     <features href="gmp-graphiti.aggrcon#//@repositories.0/@features.3"/>

--- a/sirius.aggrcon
+++ b/sirius.aggrcon
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Eclipse Sirius" label="Sirius Desktop">
-  <repositories location="https://download.eclipse.org/sirius/updates/releases/7.3.0/2023-03">
+  <repositories location="https://download.eclipse.org/sirius/updates/milestones/7.4.0M1/2023-03/">
     <features name="org.eclipse.sirius.specifier.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
-    <features name="org.eclipse.sirius.runtime.ide.eef.feature.group" enabled="false"/>
     <features name="org.eclipse.sirius.aql.feature.group"/>
     <features name="org.eclipse.sirius.samples.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>


### PR DESCRIPTION
This version includes https://github.com/eclipse-sirius/sirius-desktop/pull/223 which brings compatibbility with Guava 33.
