### PR TITLE
LSP4J 0.21.2 for 2024-03 M1

### DIFF
--- a/lsp4j.aggrcon
+++ b/lsp4j.aggrcon
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Lsp4j">
-  <repositories location="https://download.eclipse.org/lsp4j/updates/releases/0.21.1/" description="Lsp4j p2 repository">
-    <features name="org.eclipse.lsp4j.sdk.feature.group" versionRange="[0.21.1.v20230829-0014]">
+  <repositories location="https://download.eclipse.org/lsp4j/updates/releases/0.21.2/" description="Lsp4j p2 repository">
+    <features name="org.eclipse.lsp4j.sdk.feature.group" versionRange="[0.21.2.v20240110-1543]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
   </repositories>


### PR DESCRIPTION
This is a dependency update to widen Guava and include newer websocket dependency in p2 repo