### PR TITLE
Update buildship to 3.1.9

### DIFF
--- a/buildship.aggrcon
+++ b/buildship.aggrcon
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Buildship: Eclipse Plug-ins for Gradle" label="Buildship">
-  <repositories location="https://download.eclipse.org/buildship/updates/e427/releases/3.x/3.1.8.v20231117-1658">
-    <features name="org.eclipse.buildship.feature.group" versionRange="3.1.8">
+  <repositories location="https://download.eclipse.org/buildship/updates/latest-snapshot">
+    <features name="org.eclipse.buildship.feature.group" versionRange="3.1.9">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
   </repositories>


### PR DESCRIPTION
This uses a snapshop repo which is not a good thing, but since there is nothing downstream from buildship in terms of dependencies, this should not cause any problems. I really want to eliminate the older guava version from M1 and this is the only way.

https://github.com/eclipse/buildship/pull/1292