### PR TITLE
Eclipse Passage 2.11.0 for 2024-03

### DIFF
--- a/passage.aggrcon
+++ b/passage.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Passage">
-  <repositories location="https://download.eclipse.org/passage/updates/milestone/2.11.0-RC2/ldc/" description="Eclipse Passage LDC 2.11.0">
+  <repositories location="https://download.eclipse.org/passage/updates/release/2.11.0/ldc/" description="Eclipse Passage LDC 2.11.0">
     <features name="org.eclipse.passage.ldc.feature.feature.group" versionRange="[2.11.0.v20240226-1455]">
       <categories href="simrel.aggr#//@customCategories[identifier='License%20Management']"/>
     </features>


### PR DESCRIPTION
https://download.eclipse.org/passage/updates/release/2.11.0/ldc/