### PR TITLE
Use release repository url for GEF Classic 3.19

### DIFF
--- a/gef.aggrcon
+++ b/gef.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="GEF">
-  <repositories location="https://download.eclipse.org/tools/gef/classic/milestone/S202402212051" description="GEF-Classic releases">
+  <repositories location="https://download.eclipse.org/tools/gef/classic/release/3.19.0" description="GEF-Classic releases">
     <features name="org.eclipse.gef.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>


### PR DESCRIPTION
The milestone repository will be deleted with the upcoming release. Both repositories are identical, so this change merely avoids potential build errors during the 2024-06 release cycle