### PR TITLE
EMF Services: disable EMF Query

### DIFF
--- a/emf-services.aggrcon
+++ b/emf-services.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF Services">
-  <repositories location="https://download.eclipse.org/modeling/emf/query/updates/releases/R202208101410" description="EMF Query">
+  <repositories enabled="false" location="https://download.eclipse.org/modeling/emf/query/updates/releases/R202208101410" description="EMF Query">
     <features name="org.eclipse.emf.query.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>


### PR DESCRIPTION
With https://github.com/eclipse-emf-parsley/emf-parsley/issues/93 the last dependency on EMF Query in the SimRel is gone.