### PR TITLE
CDT 11.6.0 RC1 and CDT-LSP 2.0.0 RC1 for 2024-06 RC1

### DIFF
--- a/cdt.aggrcon
+++ b/cdt.aggrcon
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="CDT">
-  <repositories location="https://download.eclipse.org/tools/cdt/builds/11.6/cdt-11.6.0-m3a/" description="CDT updates">
+  <repositories location="https://download.eclipse.org/tools/cdt/builds/11.6/cdt-11.6.0-rc1/" description="CDT updates">
     <bundles name="org.eclipse.cdt.core.linux" versionRange="[6.1.100.202402230238]"/>
-    <bundles name="org.eclipse.cdt.core.linux.x86_64" versionRange="[11.6.0.202405242233]"/>
-    <bundles name="org.eclipse.cdt.core.macosx" versionRange="[11.6.0.202405242233]"/>
+    <bundles name="org.eclipse.cdt.core.linux.x86_64" versionRange="[11.6.0.202405291838]"/>
+    <bundles name="org.eclipse.cdt.core.macosx" versionRange="[11.6.0.202405291838]"/>
     <bundles name="org.eclipse.cdt.core.win32" versionRange="[6.1.100.202402230238]"/>
-    <bundles name="org.eclipse.cdt.core.linux.aarch64" versionRange="[11.6.0.202405242233]"/>
-    <features name="org.eclipse.cdt.feature.group" versionRange="[11.6.0.202405242233]">
+    <bundles name="org.eclipse.cdt.core.linux.aarch64" versionRange="[11.6.0.202405291838]"/>
+    <features name="org.eclipse.cdt.feature.group" versionRange="[11.6.0.202405291838]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[11.6.0.202405242233]">
+    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[11.6.0.202405291838]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
     <features name="org.eclipse.cdt.debug.gdbjtag.feature.group" versionRange="[11.6.0.202403071917]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
-    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[11.6.0.202405242233]"/>
+    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[11.6.0.202405291838]"/>
     <features name="org.eclipse.cdt.debug.ui.memory.feature.group" versionRange="[11.6.0.202403071917]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
@@ -45,7 +45,7 @@
     <features name="org.eclipse.cdt.docker.launcher.feature.group" versionRange="[11.6.0.202403071917]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.debug.standalone.feature.group" versionRange="[11.6.0.202405122012]"/>
+    <features name="org.eclipse.cdt.debug.standalone.feature.group" versionRange="[11.6.0.202405291831]"/>
     <features name="org.eclipse.cdt.cmake.feature.group" versionRange="[11.6.0.202403071917]"/>
     <features name="org.eclipse.cdt.launch.serial.feature.feature.group" versionRange="[11.6.0.202403071917]"/>
     <features name="org.eclipse.tm.terminal.connector.remote.feature.feature.group" versionRange="[11.6.0.202403071917]">
@@ -72,11 +72,11 @@
     <features name="org.eclipse.remote.serial.feature.group" versionRange="[11.6.0.202403071917]"/>
     <features name="org.eclipse.remote.proxy.feature.group" versionRange="[11.6.0.202403071917]"/>
   </repositories>
-  <repositories location="https://download.eclipse.org/tools/cdt/builds/cdt-lsp-2.0/cdt-lsp-2.0.0-m3a/">
-    <features name="org.eclipse.cdt.lsp.feature.feature.group" versionRange="[2.0.0.202405251203]">
+  <repositories location="https://download.eclipse.org/tools/cdt/builds/cdt-lsp-2.0/cdt-lsp-2.0.0-rc1">
+    <features name="org.eclipse.cdt.lsp.feature.feature.group" versionRange="[2.0.0.202405291704]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.lsp.feature.source.feature.group" versionRange="[2.0.0.202405251203]"/>
+    <features name="org.eclipse.cdt.lsp.feature.source.feature.group" versionRange="[2.0.0.202405291704]"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='jonah@kichwacoders.com']"/>
 </aggregator:Contribution>


### PR DESCRIPTION
We decided to deploy some important fixes into RC1 to maximize testing time.