### PR TITLE
Exclude org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group

### DIFF
--- a/gef.aggrcon
+++ b/gef.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="GEF">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="GEF">
   <repositories location="https://download.eclipse.org/tools/gef/classic/milestone/S202405290843" description="GEF Classic releases">
     <features name="org.eclipse.gef.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
@@ -47,6 +47,7 @@
     <features name="org.eclipse.fx.runtime.min.feature.feature.group" versionRange="[3.9.0.202210162353]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
+    <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" versionRange="[1.1.600.v20220215-0126]"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='matthias.wienand@itemis.de']"/>
 </aggregator:Contribution>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <version>4.26.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <tycho-version>4.0.7</tycho-version>
+    <tycho-version>4.0.8</tycho-version>
     <trainName>2024-06</trainName>
     <referenceRepo>releases/2024-03/202403131000</referenceRepo>
     <download.eclipse.org>https://download.eclipse.org</download.eclipse.org>


### PR DESCRIPTION
- Specifically version 1.1.600.v20220215-0126 from https://download.eclipse.org/efxclipse/runtime-released/3.9.0/site

https://github.com/eclipse-simrel/simrel.build/issues/399 https://github.com/eclipse-packaging/packages/issues/171