### PR TITLE
Exclude org.apache.commons.jxpath/1.3.0.v200911051830 from gef.aggrcon

### DIFF
--- a/gef.aggrcon
+++ b/gef.aggrcon
@@ -48,6 +48,7 @@
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
     <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" versionRange="[1.1.600.v20220215-0126]"/>
+    <mapRules xsi:type="aggregator:ExclusionRule" name="org.apache.commons.jxpath" versionRange="[1.3.0.v200911051830]"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='alois.zoitl@gmx.at']"/>
 </aggregator:Contribution>


### PR DESCRIPTION
https://github.com/eclipse-simrel/simrel.build/issues/438