### PR TITLE
Contribute Oomph 1.34 M3 for 2024-09 M3

### DIFF
--- a/gef.aggrcon
+++ b/gef.aggrcon
@@ -49,6 +49,7 @@
     </features>
     <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" versionRange="[1.1.600.v20220215-0126]"/>
     <mapRules xsi:type="aggregator:ExclusionRule" name="org.apache.commons.jxpath" versionRange="[1.3.0.v200911051830]"/>
+    <mapRules xsi:type="aggregator:ExclusionRule" name="org.apache.commons.logging" versionRange="[1.2.0.v20180409-1502]"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='alois.zoitl@gmx.at']"/>
 </aggregator:Contribution>

--- a/oomph.aggrcon
+++ b/oomph.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Oomph">
-  <repositories location="https://download.eclipse.org/oomph/drops/milestone/S20240730-162434-1.34.0-M2" description="Oomph 1.34">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Oomph">
+  <repositories location="https://download.eclipse.org/oomph/drops/milestone/S20240820-060425-1.34.0-M3" description="Oomph 1.34">
     <features name="org.eclipse.oomph.setup.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
@@ -20,7 +20,6 @@
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
     <features name="org.eclipse.oomph.setup.mylyn.feature.group"/>
-    <mapRules xsi:type="aggregator:ExclusionRule" name="org.apache.commons.logging" versionRange="[1.2.0.v20180409-1502]"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='ed.merks@gmail.com']"/>
 </aggregator:Contribution>


### PR DESCRIPTION
- Move org.apache.commons.logging 1.2.0.v20180409-1502 exclusion to GEF's contribution.