### PR TITLE
Contribute Buildship 3.1.10

### DIFF
--- a/buildship.aggrcon
+++ b/buildship.aggrcon
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Buildship: Eclipse Plug-ins for Gradle" label="Buildship">
-  <repositories location="https://download.eclipse.org/buildship/updates/e427/releases/3.x/3.1.9.v20240115-1636">
-    <features name="org.eclipse.buildship.feature.group" versionRange="3.1.9">
+  <repositories location="https://download.eclipse.org/buildship/updates/e427/releases/3.x/3.1.10.v20240802-1314">
+    <features name="org.eclipse.buildship.feature.group" versionRange="3.1.10">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
   </repositories>


### PR DESCRIPTION
See [Buildship 3.1.10 announcement](https://discuss.gradle.org/t/buildship-3-1-10-is-now-available/49045).

@donat Could you please approve or are there reasons not to contribute Buildship 3.1.10 to the Eclipse IDE 2024-09 release?