### PR TITLE
Contribute a pre-m2 version of the platform with riscv64 support

### DIFF
--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse">
-  <repositories location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/I20240926-1800" description="Eclipse and Equinox">
+  <repositories location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/I20241003-1800" description="Eclipse and Equinox">
     <products name="org.eclipse.sdk.ide"/>
     <products name="org.eclipse.platform.ide"/>
     <bundles name="org.eclipse.e4.ui.progress"/>

--- a/simrel.aggr
+++ b/simrel.aggr
@@ -65,6 +65,7 @@
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="aarch64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="ppc64le"/>
+  <configurations operatingSystem="linux" windowSystem="gtk" architecture="riscv64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="x86_64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="aarch64"/>
   <configurations architecture="aarch64"/>


### PR DESCRIPTION
- Update simrel.aggr to include a riscv64 configuration.