### PR TITLE
Remove explicit bundles from CDT's contribution

### DIFF
--- a/cdt.aggrcon
+++ b/cdt.aggrcon
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="CDT">
   <repositories location="https://download.eclipse.org/tools/cdt/releases/11.6/cdt-11.6.1/" description="CDT updates">
-    <bundles name="org.eclipse.cdt.core.linux" versionRange="[6.1.100.202402230238]"/>
-    <bundles name="org.eclipse.cdt.core.linux.x86_64" versionRange="[11.6.1.202407022008]"/>
-    <bundles name="org.eclipse.cdt.core.macosx" versionRange="[11.6.1.202407022008]"/>
-    <bundles name="org.eclipse.cdt.core.win32" versionRange="[6.1.100.202402230238]"/>
-    <bundles name="org.eclipse.cdt.core.linux.aarch64" versionRange="[11.6.1.202407022008]"/>
     <features name="org.eclipse.cdt.feature.group" versionRange="[11.6.1.202407022008]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>


### PR DESCRIPTION
These bundles have been manually listed for a long time (since first version of these files in 2012). However these bundles end up in the output even if not manually listed, therefore remove them being explicit.

The secondary issue with this explicit list is that there are other native bundles not listed here, so this commit also resolves this inconsistency.