### PR TITLE
CDT 12.0.0 M2a for 2025-03 M2

### DIFF
--- a/cdt.aggrcon
+++ b/cdt.aggrcon
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="CDT">
-  <repositories location="https://download.eclipse.org/tools/cdt/builds/12.0/cdt-12.0.0-m2/" description="CDT updates">
-    <features name="org.eclipse.cdt.feature.group" versionRange="[12.0.0.202501271737]">
+  <repositories location="https://download.eclipse.org/tools/cdt/builds/12.0/cdt-12.0.0-m2a/" description="CDT updates">
+    <features name="org.eclipse.cdt.feature.group" versionRange="[12.0.0.202501291927]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[12.0.0.202501271737]">
+    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[12.0.0.202501291927]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
     <features name="org.eclipse.cdt.debug.gdbjtag.feature.group" versionRange="[12.0.0.202501070137]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
-    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[12.0.0.202501271737]"/>
+    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[12.0.0.202501291927]"/>
     <features name="org.eclipse.cdt.debug.ui.memory.feature.group" versionRange="[12.0.0.202501271731]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
@@ -41,7 +41,7 @@
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
     <features name="org.eclipse.cdt.debug.standalone.feature.group" versionRange="[12.0.0.202410081652]"/>
-    <features name="org.eclipse.cdt.cmake.feature.group" versionRange="[12.0.0.202501271731]"/>
+    <features name="org.eclipse.cdt.cmake.feature.group" versionRange="[12.0.0.202501282354]"/>
     <features name="org.eclipse.cdt.launch.serial.feature.feature.group" versionRange="[12.0.0.202410081652]"/>
     <features name="org.eclipse.tm.terminal.connector.remote.feature.feature.group" versionRange="[12.0.0.202501070137]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
@@ -56,7 +56,7 @@
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
     <features name="org.eclipse.launchbar.remote.feature.group" versionRange="[12.0.0.202410081652]"/>
-    <features name="org.eclipse.cdt.meson.feature.group" versionRange="[12.0.0.202501070137]"/>
+    <features name="org.eclipse.cdt.meson.feature.group" versionRange="[12.0.0.202501282354]"/>
     <features name="org.eclipse.cdt.unittest.feature.feature.group" versionRange="[12.0.0.202501070137]"/>
     <features name="org.eclipse.remote.feature.group" versionRange="[12.0.0.202501070137]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>


### PR DESCRIPTION
This is a respin of CDT's M2 contribution to include the major version bump of org.eclipse.cdt.core/ui as I wanted to get the new version into SimRel ASAP to ensure everyone downstream could cope with it properly.