### PR TITLE
Simrel updates for Eclipse and Equinox for 2025-03 pre-M3

### DIFF
--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse">
-  <repositories location="https://download.eclipse.org/eclipse/updates/4.35-I-builds/I20250123-1800" description="Eclipse and Equinox">
+  <repositories location="https://download.eclipse.org/eclipse/updates/4.35-I-builds/I20250211-1800" description="Eclipse and Equinox">
     <products name="org.eclipse.sdk.ide"/>
     <products name="org.eclipse.platform.ide"/>
     <bundles name="org.eclipse.e4.ui.progress"/>

--- a/modisco.aggrcon
+++ b/modisco.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="MoDisco for 2025-03">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" label="MoDisco for 2025-03">
   <repositories location=" https://download.eclipse.org/modeling/mdt/modisco/builds/milestone/S202502091609" description="MoDisco">
     <features name="org.eclipse.modisco.sdk.feature.feature.group" versionRange="[1.5.6,1.6.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>


### PR DESCRIPTION
- Contribute a current I-build to ensure that aggregation continues to work in preparation for this weeks actual M3 contributions.
- Disable modisco to ensure that an updated modisco build with missing transitive jxpath dependencies can be tested for successful aggregation.

https://github.com/eclipse-modisco/org.eclipse.modisco/issues/1085