### PR TITLE
Simrel updates for Eclipse and Equinox for 2025-03 pre-M3

### DIFF
--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse">
-  <repositories location="https://download.eclipse.org/eclipse/updates/4.35-I-builds/I20250211-1800" description="Eclipse and Equinox">
+  <repositories location="https://download.eclipse.org/eclipse/updates/4.35-I-builds/I20250212-0500" description="Eclipse and Equinox">
     <products name="org.eclipse.sdk.ide"/>
     <products name="org.eclipse.platform.ide"/>
-    <bundles name="org.eclipse.e4.ui.progress"/>
-    <bundles name="org.eclipse.e4.ui.progress.source"/>
+    <bundles name="org.eclipse.equinox.slf4j"/>
     <bundles name="jakarta.inject.jakarta.inject-api" versionRange="[1.0.0,2.0.0)"/>
     <bundles name="jakarta.annotation-api" versionRange="[1.0.0,2.0.0)"/>
     <features name="org.eclipse.sdk.feature.group">


### PR DESCRIPTION
- Update to a version that includes org.eclipse.equinox.slf4j and explicitly require that bundle.
- Remove org.eclipse.e4.ui.progress because it's included by an already-included feature.