### PR TITLE
Remove explicitly dependencies on source.feature.group

### DIFF
--- a/egit.aggrcon
+++ b/egit.aggrcon
@@ -8,8 +8,6 @@
     <features name="org.eclipse.egit.feature.group" versionRange="[7.3.0.202504081226-m1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
-    <features name="org.eclipse.egit.source.feature.group" versionRange="[7.3.0.202504081226-m1]"/>
-    <features name="org.eclipse.jgit.source.feature.group" versionRange="[7.3.0.202504081226-m1]"/>
     <features name="org.eclipse.jgit.http.apache.feature.group" versionRange="[7.3.0.202504081226-m1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>

--- a/simrel.aggr
+++ b/simrel.aggr
@@ -121,13 +121,13 @@
     <features href="egit.aggrcon#//@repositories.0/@features.2"/>
     <features href="dltk.aggrcon#//@repositories.0/@features.4"/>
     <features href="pdt.aggrcon#//@repositories.0/@features.2"/>
+    <features href="egit.aggrcon#//@repositories.0/@features.4"/>
+    <features href="egit.aggrcon#//@repositories.0/@features.5"/>
+    <features href="egit.aggrcon#//@repositories.0/@features.0"/>
+    <features href="egit.aggrcon#//@repositories.0/@features.3"/>
     <features href="egit.aggrcon#//@repositories.0/@features.6"/>
     <features href="egit.aggrcon#//@repositories.0/@features.7"/>
-    <features href="egit.aggrcon#//@repositories.0/@features.0"/>
-    <features href="egit.aggrcon#//@repositories.0/@features.5"/>
     <features href="egit.aggrcon#//@repositories.0/@features.8"/>
-    <features href="egit.aggrcon#//@repositories.0/@features.9"/>
-    <features href="egit.aggrcon#//@repositories.0/@features.10"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>


### PR DESCRIPTION
- Corresponding source bundles or features are always aggregated automatically if available in a p2 repository.

