### PR TITLE
Disable usssdk and use Oomph nightly build with no usssdk dependencies

### DIFF
--- a/oomph.aggrcon
+++ b/oomph.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Oomph">
-  <repositories location="https://download.eclipse.org/oomph/drops/milestone/S20250409-090627-1.37.0-M1" description="Oomph 1.37">
+  <repositories location="https://download.eclipse.org/oomph/updates/nightly/latest" description="Oomph 1.37">
     <features name="org.eclipse.oomph.setup.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>

--- a/usssdk.aggrcon
+++ b/usssdk.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="User Storage SDK">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" label="User Storage SDK">
   <repositories location="https://download.eclipse.org/usssdk/drops/release/1.2.2/" description="User Storage SDK">
     <features name="org.eclipse.userstorage.feature.group" versionRange="[1.2.0,1.3.0)"/>
     <features name="org.eclipse.userstorage.sdk.feature.group" versionRange="[1.2.0,1.3.0)">


### PR DESCRIPTION
- The Oomph change is temporary until there is an Oomph m2 milestone.
- The usssdk contribution will be deleted before m2.