### PR TITLE
Publish RAP 4.3 M2 for 2025-06 M2

### DIFF
--- a/rap-tools.aggrcon
+++ b/rap-tools.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="RAP Tools">
-  <repositories location="https://download.eclipse.org/rt/rap/tools/4.3/M1-20250409-0726/" description="RAP 4.3 Tools Repository">
+  <repositories location="https://download.eclipse.org/rt/rap/tools/4.3/M2-20250507-1338/" description="RAP 4.3 Tools Repository">
     <features name="org.eclipse.rap.tools.feature.feature.group" versionRange="[4.3.0,4.4.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Web%2C%20XML%2C%20Java%20EE%20and%20OSGi%20Enterprise%20Development']"/>
     </features>

--- a/rap.aggrcon
+++ b/rap.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="RAP Runtime">
-  <repositories location="https://download.eclipse.org/rt/rap/4.3/M1-20250409-0726/" description="RAP 4.3 Runtime Repository">
+  <repositories location="https://download.eclipse.org/rt/rap/4.3/M2-20250507-1338/" description="RAP 4.3 Runtime Repository">
     <features name="org.eclipse.rap.feature.feature.group" versionRange="[4.3.0,4.4.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
     </features>


### PR DESCRIPTION
- RAP Runtime 4.3 M2-20250507-1338
- RAP Tools 4.3 M2-20250507-1338

This build uses Eclipse Platform 4.36 build I20250506-0940.