### PR TITLE
Contribute Papyrus 7.0.0 for 2025-06 M3

### DIFF
--- a/mdt-papyrus.aggrcon
+++ b/mdt-papyrus.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Contribution of the Modeling Papyrus project" label="Papyrus">
-  <repositories location="https://download.eclipse.org/modeling/mdt/papyrus/papyrus-desktop/updates/milestones/7.0/M2/main" description="Papyrus">
+  <repositories location="https://download.eclipse.org/modeling/mdt/papyrus/papyrus-desktop/updates/milestones/7.0/M3/main" description="Papyrus">
     <features description="Papyrus SDK Feature" name="org.eclipse.papyrus.sdk.feature.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>


### PR DESCRIPTION
Some dependencies changes have been done in "Papyrus-Desktop 7.0.0 M3". A respin could occur by tomorrow if any issues are detected during our testing.