### PR TITLE
Contribute Papyrus 7.0.0 for 2025-06 M3b

### DIFF
--- a/mdt-papyrus.aggrcon
+++ b/mdt-papyrus.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Contribution of the Modeling Papyrus project" label="Papyrus">
-  <repositories location="https://download.eclipse.org/modeling/mdt/papyrus/papyrus-desktop/updates/milestones/7.0/M3/main" description="Papyrus">
+  <repositories location="https://download.eclipse.org/modeling/mdt/papyrus/papyrus-desktop/updates/milestones/7.0/M3b/main" description="Papyrus">
     <features description="Papyrus SDK Feature" name="org.eclipse.papyrus.sdk.feature.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>


### PR DESCRIPTION
This is a respin to consider the new version of GEF that fixes a problem (#733 "Infinite loop in PaletteDrawer" [1]) also detected in Papyrus (#37 "Infinite scroll in Palette of diagrams (GMF and Sirius)" [2]).

[1] https://github.com/eclipse-gef/gef-classic/issues/733
[2] https://gitlab.eclipse.org/eclipse/papyrus/org.eclipse.papyrus-desktop/-/issues/37