### PR TITLE
Remove explicit sources from lsp4e

### DIFF
--- a/lsp4e.aggrcon
+++ b/lsp4e.aggrcon
@@ -10,9 +10,6 @@
     <features name="org.eclipse.lsp4e.jdt" versionRange="[0.13.7.202505091900]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.lsp4e.source" versionRange="[0.18.25.202507141514]"/>
-    <features name="org.eclipse.lsp4e.debug.source" versionRange="[0.15.15.202501312028]"/>
-    <features name="org.eclipse.lsp4e.jdt.source" versionRange="[0.13.7.202505091900]"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='mistria@redhat.com']"/>
   <contacts href="simrel.aggr#//@contacts[email='jonah@kichwacoders.com']"/>


### PR DESCRIPTION
- The aggregator always aggregates corresponding source when available in any p2 repository.

The sources are aggregated automatically:

<img width="1133" height="190" alt="image" src="https://github.com/user-attachments/assets/bd3c6808-861d-4a31-93de-3398bcf5ba34" />

So this will reduce the maintenance overhead:

FYI: @rubenporras
