### PR TITLE
Simrel updates for Eclipse and Equinox for 2025-09 M2

### DIFF
--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse">
-  <repositories location="https://download.eclipse.org/eclipse/updates/4.37-I-builds/I20250708-0510" description="Eclipse and Equinox">
+  <repositories location="https://download.eclipse.org/eclipse/updates/4.37-I-builds/I20250724-1800" description="Eclipse and Equinox">
     <products name="org.eclipse.sdk.ide"/>
     <products name="org.eclipse.platform.ide"/>
     <bundles name="org.eclipse.equinox.slf4j"/>

--- a/mdt-papyrus.aggrcon
+++ b/mdt-papyrus.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Contribution of the Modeling Papyrus project" label="Papyrus" enabled="false">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" description="Contribution of the Modeling Papyrus project" label="Papyrus">
   <repositories location="https://download.eclipse.org/modeling/mdt/papyrus/papyrus-desktop/updates/milestones/7.0/RC2/main" description="Papyrus">
     <features description="Papyrus SDK Feature" name="org.eclipse.papyrus.sdk.feature.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>

--- a/simrel.aggran
+++ b/simrel.aggran
@@ -782,6 +782,7 @@
     </project>
   </contribution>
   <contribution
+      enabled="false"
       contribution="mdt-papyrus.aggrcon#/">
     <project
         name="Eclipse Papyrus"
@@ -910,6 +911,7 @@
     </project>
   </contribution>
   <contribution
+      enabled="false"
       contribution="xwt.aggrcon#/">
     <project
         name="Eclipse XWT"

--- a/webtools.aggrcon
+++ b/webtools.aggrcon
@@ -94,5 +94,8 @@
     <bundles name="org.eclipse.wtp.web.capabilities" versionRange="1.0.100.v201005102000"/>
     <bundles name="org.eclipse.wtp.xml.capabilities" versionRange="1.0.100.v201005102000"/>
   </repositories>
+  <repositories location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest">
+    <bundles name="com.sun.el.javax.el"/>
+  </repositories>
   <contacts href="simrel.aggr#//@contacts[email='thatnitind@gmail.com']"/>
 </aggregator:Contribution>

--- a/xwt.aggrcon
+++ b/xwt.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="XWT - Declarative UI in XML for Eclipse" label="XWT" enabled="false">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" description="XWT - Declarative UI in XML for Eclipse" label="XWT">
   <repositories location="https://download.eclipse.org/xwt/release-1.9.200">
     <features description="XWT Runtime" name="org.eclipse.xwt.feature.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>


### PR DESCRIPTION
- Normalize the serialization of papyrus and xwt.
- Update WTP to add temporarily the orbit milestone to provide com.sun.el.javax.el.
- Update simrel.aggran to reflect the disablment of papyrus and xwt.