### PR TITLE
Simrel updates for Eclipse and Equinox for 2025-09 RC1

### DIFF
--- a/egit.aggrcon
+++ b/egit.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EGit">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EGit">
   <repositories location="https://download.eclipse.org/egit/staging/v7.4.0.202508191000-m3" description="EGit Updates">
     <features name="org.eclipse.jgit.feature.group" versionRange="[7.4.0.202508191000-m3]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
@@ -26,10 +26,6 @@
     <features name="org.eclipse.jgit.ssh.jsch.feature.group" versionRange="[7.4.0.202508191000-m3]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
-    <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.jetty.http" versionRange="[12.1.0]"/>
-    <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.jetty.security" versionRange="[12.1.0]"/>
-    <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.jetty.server" versionRange="[12.1.0]"/>
-    <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.jetty.util" versionRange="[12.1.0]"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='matthias.sohn@gmail.com']"/>
 </aggregator:Contribution>

--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse">
-  <repositories location="https://download.eclipse.org/eclipse/updates/4.37-I-builds/I20250814-1800" description="Eclipse and Equinox">
+  <repositories location="https://download.eclipse.org/eclipse/updates/4.37-I-builds/I20250820-1800" description="Eclipse and Equinox">
     <products name="org.eclipse.sdk.ide"/>
     <products name="org.eclipse.platform.ide"/>
     <bundles name="org.eclipse.equinox.slf4j"/>


### PR DESCRIPTION
- Remove EGit.aggrcon's exclusion of Jetty 12.1.0.

https://github.com/eclipse-simrel/simrel.build/pull/995