### PR TITLE
Publish RAP 4.4 RC1 for 2025-09 RC1

### DIFF
--- a/rap-tools.aggrcon
+++ b/rap-tools.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="RAP Tools">
-  <repositories location="https://download.eclipse.org/rt/rap/tools/4.4/M3-20250820-1530/" description="RAP 4.4 Tools Repository">
+  <repositories location="https://download.eclipse.org/rt/rap/tools/4.4/RC1-20250826-0731/" description="RAP 4.4 Tools Repository">
     <features name="org.eclipse.rap.tools.feature.feature.group" versionRange="[4.4.0,4.5.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Web%2C%20XML%2C%20Java%20EE%20and%20OSGi%20Enterprise%20Development']"/>
     </features>


### PR DESCRIPTION
- RAP Tools 4.4 RC1-20250826-0731

Early RC1 commit in order to sync Jetty versions. Work on dependency structure continues in parallel.