### PR TITLE
CDT 12.3.0 and CDT LSP 3.4.0 for 2025-12 M1

### DIFF
--- a/cdt.aggrcon
+++ b/cdt.aggrcon
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="CDT">
-  <repositories location="https://download.eclipse.org/tools/cdt/releases/12.2/" description="CDT updates">
-    <features name="org.eclipse.cdt.feature.group" versionRange="[12.2.0.202509030008]">
+  <repositories location="https://download.eclipse.org/tools/cdt/builds/12.3/cdt-12.3.0-m1/" description="CDT updates">
+    <features name="org.eclipse.cdt.feature.group" versionRange="[12.3.0.202510062116]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[12.2.0.202509030008]">
+    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[12.3.0.202510062116]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.debug.gdbjtag.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.cdt.debug.gdbjtag.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
-    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[12.2.0.202509030008]"/>
-    <features name="org.eclipse.cdt.debug.ui.memory.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[12.3.0.202510062116]"/>
+    <features name="org.eclipse.cdt.debug.ui.memory.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
-    <features name="org.eclipse.cdt.launch.remote.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.cdt.launch.remote.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.build.crossgcc.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.cdt.build.crossgcc.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
-    <features name="org.eclipse.cdt.msw.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.cdt.msw.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.autotools.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.cdt.autotools.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.testsrunner.feature.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.cdt.testsrunner.feature.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.visualizer.feature.group" versionRange="[12.2.0.202506091931]"/>
-    <features name="org.eclipse.cdt.managedbuilder.llvm.feature.group" versionRange="[12.2.0.202508181550]">
+    <features name="org.eclipse.cdt.visualizer.feature.group" versionRange="[12.3.0.202509101333]"/>
+    <features name="org.eclipse.cdt.managedbuilder.llvm.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.gnu.multicorevisualizer.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.cdt.gnu.multicorevisualizer.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.docker.launcher.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.cdt.docker.launcher.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.debug.standalone.feature.group" versionRange="[12.2.0.202506091931]"/>
-    <features name="org.eclipse.cdt.cmake.feature.group" versionRange="[12.2.0.202506091931]"/>
-    <features name="org.eclipse.cdt.launch.serial.feature.feature.group" versionRange="[12.2.0.202506091931]"/>
-    <features name="org.eclipse.tm.terminal.connector.remote.feature.feature.group" versionRange="[12.2.0.202507231751]">
+    <features name="org.eclipse.cdt.debug.standalone.feature.group" versionRange="[12.3.0.202509101333]"/>
+    <features name="org.eclipse.cdt.cmake.feature.group" versionRange="[12.3.0.202509101333]"/>
+    <features name="org.eclipse.cdt.launch.serial.feature.feature.group" versionRange="[12.3.0.202509101333]"/>
+    <features name="org.eclipse.tm.terminal.connector.remote.feature.feature.group" versionRange="[12.3.0.202510031403]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.tm.terminal.feature.feature.group" versionRange="[12.2.0.202507251115]">
+    <features name="org.eclipse.tm.terminal.feature.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.tm.terminal.connector.cdtserial.feature.feature.group" versionRange="[12.2.0.202507250901]">
+    <features name="org.eclipse.tm.terminal.connector.cdtserial.feature.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.launchbar.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.launchbar.feature.group" versionRange="[12.3.0.202509240945]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.launchbar.remote.feature.group" versionRange="[12.2.0.202506091931]"/>
-    <features name="org.eclipse.cdt.meson.feature.group" versionRange="[12.2.0.202506091931]"/>
-    <features name="org.eclipse.cdt.unittest.feature.feature.group" versionRange="[12.2.0.202506091931]"/>
-    <features name="org.eclipse.remote.feature.group" versionRange="[12.2.0.202506091931]">
+    <features name="org.eclipse.launchbar.remote.feature.group" versionRange="[12.3.0.202509101333]"/>
+    <features name="org.eclipse.cdt.meson.feature.group" versionRange="[12.3.0.202509101333]"/>
+    <features name="org.eclipse.cdt.unittest.feature.feature.group" versionRange="[12.3.0.202509101333]"/>
+    <features name="org.eclipse.remote.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.remote.console.feature.group" versionRange="[12.2.0.202507191614]">
+    <features name="org.eclipse.remote.console.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.remote.serial.feature.group" versionRange="[12.2.0.202506091931]"/>
-    <features name="org.eclipse.remote.proxy.feature.group" versionRange="[12.2.0.202506091931]"/>
+    <features name="org.eclipse.remote.serial.feature.group" versionRange="[12.3.0.202509101333]"/>
+    <features name="org.eclipse.remote.proxy.feature.group" versionRange="[12.3.0.202509101333]"/>
   </repositories>
-  <repositories location="https://download.eclipse.org/tools/cdt/releases/cdt-lsp-3.3/">
-    <features name="org.eclipse.cdt.lsp.feature.feature.group" versionRange="[3.3.0.202509030041]">
+  <repositories location="https://download.eclipse.org/tools/cdt/builds/cdt-lsp-3.4/cdt-lsp-3.4.0-m1/">
+    <features name="org.eclipse.cdt.lsp.feature.feature.group" versionRange="[3.4.0.202510062110]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
   </repositories>

--- a/pdt.aggrcon
+++ b/pdt.aggrcon
@@ -24,5 +24,8 @@
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
   </repositories>
+  <repositories location="https://download.eclipse.org/tools/cdt/releases/12.1/cdt-12.1.0/">
+    <features name="org.eclipse.tm.terminal.view.feature.feature.group" versionRange="[12.1.0.202506041901]"/>
+  </repositories>
   <contacts href="simrel.aggr#//@contacts[email='zulus@w3des.net']"/>
 </aggregator:Contribution>


### PR DESCRIPTION
This includes an old version of CDT to that PDT (and TCF probably) can continue to be included with the dependency on the older terminal bundles.