### PR TITLE
Remove old CDT contributed to enable PDT to work and disable TCF

### DIFF
--- a/pdt.aggrcon
+++ b/pdt.aggrcon
@@ -24,8 +24,5 @@
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
   </repositories>
-  <repositories location="https://download.eclipse.org/tools/cdt/releases/12.1/cdt-12.1.0/">
-    <features name="org.eclipse.tm.terminal.view.feature.feature.group" versionRange="[12.1.0.202506041901]"/>
-  </repositories>
   <contacts href="simrel.aggr#//@contacts[email='zulus@w3des.net']"/>
 </aggregator:Contribution>

--- a/tcf.aggrcon
+++ b/tcf.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="TCF for SimRel 2021-09">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" label="TCF for SimRel 2021-09">
   <repositories location="https://download.eclipse.org/tools/tcf/releases/1.7/1.7.0" description="TCF 1.7.0">
     <features name="org.eclipse.tcf.cdt.feature.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>


### PR DESCRIPTION
PDT has contributed a new version that uses new Eclipse Terminal namespace in https://github.com/eclipse-simrel/simrel.build/pull/1057

As of now there has been no response from TCF project, so I am disabling TCF rather than continuing to contribute an older CDT site to SimRel.