### PR TITLE
CDT & CDT LSP contribution for 2025-12 M2

### DIFF
--- a/cdt.aggrcon
+++ b/cdt.aggrcon
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="CDT">
-  <repositories location="https://download.eclipse.org/tools/cdt/builds/12.3/cdt-12.3.0-m1/" description="CDT updates">
-    <features name="org.eclipse.cdt.feature.group" versionRange="[12.3.0.202510062116]">
+  <repositories location="https://download.eclipse.org/tools/cdt/builds/12.3/cdt-12.3.0-m2/" description="CDT updates">
+    <features name="org.eclipse.cdt.feature.group" versionRange="[12.3.0.202510211602]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[12.3.0.202510062116]">
+    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[12.3.0.202510211602]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
     <features name="org.eclipse.cdt.debug.gdbjtag.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
-    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[12.3.0.202510062116]"/>
+    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[12.3.0.202510211602]"/>
     <features name="org.eclipse.cdt.debug.ui.memory.feature.group" versionRange="[12.3.0.202509101333]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
@@ -43,13 +43,10 @@
     <features name="org.eclipse.cdt.debug.standalone.feature.group" versionRange="[12.3.0.202509101333]"/>
     <features name="org.eclipse.cdt.cmake.feature.group" versionRange="[12.3.0.202509101333]"/>
     <features name="org.eclipse.cdt.launch.serial.feature.feature.group" versionRange="[12.3.0.202509101333]"/>
-    <features name="org.eclipse.tm.terminal.connector.remote.feature.feature.group" versionRange="[12.3.0.202510031403]">
+    <features name="org.eclipse.tm.terminal.connector.remote.feature.feature.group" versionRange="[12.3.0.202510151654]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.tm.terminal.feature.feature.group" versionRange="[12.3.0.202509101333]">
-      <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
-    </features>
-    <features name="org.eclipse.tm.terminal.connector.cdtserial.feature.feature.group" versionRange="[12.3.0.202509101333]">
+    <features name="org.eclipse.tm.terminal.connector.cdtserial.feature.feature.group" versionRange="[12.3.0.202510151654]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
     <features name="org.eclipse.launchbar.feature.group" versionRange="[12.3.0.202509240945]">
@@ -67,8 +64,8 @@
     <features name="org.eclipse.remote.serial.feature.group" versionRange="[12.3.0.202509101333]"/>
     <features name="org.eclipse.remote.proxy.feature.group" versionRange="[12.3.0.202509101333]"/>
   </repositories>
-  <repositories location="https://download.eclipse.org/tools/cdt/builds/cdt-lsp-3.4/cdt-lsp-3.4.0-m1/">
-    <features name="org.eclipse.cdt.lsp.feature.feature.group" versionRange="[3.4.0.202510062110]">
+  <repositories location="https://download.eclipse.org/tools/cdt/builds/cdt-lsp-3.4/cdt-lsp-3.4.0-m2/">
+    <features name="org.eclipse.cdt.lsp.feature.feature.group" versionRange="[3.4.0.202510180548]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
   </repositories>

--- a/simrel.aggr
+++ b/simrel.aggr
@@ -220,15 +220,14 @@
     <features href="lsp4e.aggrcon#//@repositories.0/@features.1"/>
     <features href="ocl.aggrcon#//@repositories.0/@features.0"/>
     <features href="ep.aggrcon#//@repositories.0/@features.8"/>
-    <features href="cdt.aggrcon#//@repositories.0/@features.20"/>
+    <features href="cdt.aggrcon#//@repositories.0/@features.19"/>
     <features href="cdt.aggrcon#//@repositories.0/@features.17"/>
     <features href="cdt.aggrcon#//@repositories.0/@features.18"/>
-    <features href="cdt.aggrcon#//@repositories.0/@features.19"/>
     <features href="lsp4e.aggrcon#//@repositories.0/@features.2"/>
     <features href="ep.aggrcon#//@repositories.0/@features.9"/>
     <features href="m2e.aggrcon#//@repositories.0/@features.4"/>
+    <features href="cdt.aggrcon#//@repositories.0/@features.23"/>
     <features href="cdt.aggrcon#//@repositories.0/@features.24"/>
-    <features href="cdt.aggrcon#//@repositories.0/@features.25"/>
     <features href="ep.aggrcon#//@repositories.0/@features.3"/>
     <features href="ep.aggrcon#//@repositories.0/@features.17"/>
   </customCategories>


### PR DESCRIPTION
Include removal of the last part of TM terminal that has now been migrated to the platform.

org.eclipse.tm.terminal.feature.feature.group is now in Platform as org.eclipse.terminal.feature.feature.group.

The remaining org.eclipse.tm.terminal.* features are the serial and remote connectors that CDT will continue to provide.