### PR TITLE
Ensure that all the current versions of a.jre.javase are aggregated

### DIFF
--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -3,6 +3,13 @@
   <repositories location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/I20260515-1811" description="Eclipse and Equinox">
     <products name="org.eclipse.sdk.ide"/>
     <products name="org.eclipse.platform.ide"/>
+    <bundles name="a.jre.javase" versionRange="[21.0.0,22.0.0)"/>
+    <bundles name="a.jre.javase" versionRange="[22.0.0,23.0.0)"/>
+    <bundles name="a.jre.javase" versionRange="[23.0.0,24.0.0)"/>
+    <bundles name="a.jre.javase" versionRange="[24.0.0,25.0.0)"/>
+    <bundles name="a.jre.javase" versionRange="[25.0.0,26.0.0)"/>
+    <bundles name="a.jre.javase" versionRange="[26.0.0,27.0.0)"/>
+    <bundles name="a.jre.javase" versionRange="[27.0.0,28.0.0)"/>
     <bundles name="org.eclipse.equinox.slf4j"/>
     <bundles name="jakarta.inject.jakarta.inject-api" versionRange="[1.0.0,2.0.0)"/>
     <bundles name="jakarta.annotation-api" versionRange="[1.0.0,2.0.0)"/>


### PR DESCRIPTION
- It's already happened that some package is removed from Java 26 and it was a package imported by an Orbit dependency so ensuring that we aggregate the full range of a.jre.javase IUs from the current SimRel BREE lower bound of 21 up to the highest available version is safest for the time being.