### PR TITLE
Publish RAP 4.7 RC1 for 2026-06 RC1

### DIFF
--- a/rap-tools.aggrcon
+++ b/rap-tools.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="RAP Tools">
-  <repositories location="https://download.eclipse.org/rt/rap/tools/4.7/M3-20260520-1354/" description="RAP 4.7 Tools Repository">
+  <repositories location="https://download.eclipse.org/rt/rap/tools/4.7/RC1-20260529-1030/" description="RAP 4.7 Tools Repository">
     <features name="org.eclipse.rap.tools.feature.feature.group" versionRange="[4.7.0,4.8.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Web%2C%20XML%2C%20Java%20EE%20and%20OSGi%20Enterprise%20Development']"/>
     </features>


### PR DESCRIPTION
This is a late contribution of RAP 4.7 RC1. Too late for RC1 itself, but good for early testing.

- RAP Tools 4.7 RC1-20260529-1030