### PR TITLE
Eclipse Passage 4.6.0 for 2026-06

### DIFF
--- a/passage.aggrcon
+++ b/passage.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Passage">
-  <repositories location="https://download.eclipse.org/passage/updates/milestone/S202606020803/" description="Eclipse Passage LDC 4.6.0">
+  <repositories location="https://download.eclipse.org/passage/updates/release/4.6.0/" description="Eclipse Passage LDC 4.6.0">
     <features name="org.eclipse.passage.ldc.feature.feature.group" versionRange="[4.6.0.v20260602-0803]">
       <categories href="simrel.aggr#//@customCategories[identifier='License%20Management']"/>
     </features>


### PR DESCRIPTION
https://download.eclipse.org/passage/updates/release/4.6.0/