### PR TITLE
Change the Oomph report generator to ignore expected duplicates

### DIFF
--- a/Jenkinsfile-oomph-report
+++ b/Jenkinsfile-oomph-report
@@ -89,6 +89,7 @@ pipeline {
              -s "${JOB_URL}" \
              -v \
              -t "tests" \
+             -ignored-major-version-duplicates "jakarta[.].*|junit-.*" \
              ${PUBLISH_ARGUMENT} \
              "https://download.eclipse.org/${TRAIN_LOCATION}" \
              -vmargs \


### PR DESCRIPTION
- It's expected that there will always be multiple major versions of various jakarta libraries as well as the junit libraries.