### PR TITLE
Reorganize the *.aggrcon

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,2 @@
 eclipse.preferences.version=1
 encoding/<project>=UTF-8
-encoding/emf-cdo.aggrcon=UTF-8
-encoding/m2e.aggrcon=ASCII
-encoding/oomph.aggrcon=UTF-8
-encoding/simrel.aggr=ASCII

--- a/acceleo.aggrcon
+++ b/acceleo.aggrcon
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="M2T ACCELEO">
+<?xml version="1.0" encoding="UTF-8"?>
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Acelleo">
   <repositories location="https://download.eclipse.org/acceleo/updates/releases/4.2/R202603201315/" description="Acceleo">
     <features name="org.eclipse.acceleo.aql.feature.feature.group" versionRange="[4.2.2]">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>

--- a/atl.aggrcon
+++ b/atl.aggrcon
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="M2M ATL">
+<?xml version="1.0" encoding="UTF-8"?>
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="ATL">
   <repositories location="https://download.eclipse.org/mmt/atl/builds/release/4.12.0" description="M2M ATL">
     <features name="org.eclipse.m2m.atl.feature.group" versionRange="4.12.0">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>

--- a/buildship.aggrcon
+++ b/buildship.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Buildship: Eclipse Plug-ins for Gradle" label="Buildship">
   <repositories location="https://download.eclipse.org/buildship/updates/e427/releases/3.x/3.1.11.v20250904-1000">
     <features name="org.eclipse.buildship.feature.group" versionRange="3.1.11">

--- a/cdo.aggrcon
+++ b/cdo.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF CDO">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="CDO">
   <repositories location="https://download.eclipse.org/modeling/emf/cdo/drops/R20260602-1248" description="EMF CDO">
     <features name="org.eclipse.net4j.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>

--- a/cdt.aggrcon
+++ b/cdt.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="CDT">
   <repositories location="https://download.eclipse.org/tools/cdt/builds/12.6/cdt-12.6.0-m2/" description="CDT updates">
     <features name="org.eclipse.cdt.feature.group" versionRange="[12.6.0.202607152339]">

--- a/dltk.aggrcon
+++ b/dltk.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="DLTK">
   <repositories location="https://download.eclipse.org/technology/dltk/updates-dev/6.4.2/" description="DLTK 6.4.2">
     <features name="org.eclipse.dltk.core.feature.group">

--- a/dtp.aggrcon
+++ b/dtp.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="DataTools">
   <repositories location="https://download.eclipse.org/datatools/updates/release/1.17.0" description="DataTools 1.17.0">
     <features name="org.eclipse.datatools.common.doc.user.feature.group">

--- a/ecf.aggrcon
+++ b/ecf.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="ECF">
   <repositories location="https://download.eclipse.org/rt/ecf/3.16.8/site.p2/3.16.8.v20260415-2025" description="ECF updates">
     <features name="org.eclipse.ecf.core.feature.feature.group" versionRange="[1.7.100.v20260415-2025]">

--- a/eclemma.aggrcon
+++ b/eclemma.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EclEmma">
   <repositories location="https://download.eclipse.org/eclemma/milestones/3.1.12-m1/">
     <features name="org.eclipse.eclemma.feature.feature.group" versionRange="[3.1.12.202606121545]">

--- a/ecoretools.aggrcon
+++ b/ecoretools.aggrcon
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMFT Ecore Tools">
+<?xml version="1.0" encoding="UTF-8"?>
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Ecore Tools">
   <repositories location="https://download.eclipse.org/ecoretools/updates/milestones/3.6.0M1/2025-09" description="EMFT Ecore Tools">
     <features name="org.eclipse.emf.ecoretools.design.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>

--- a/eef.aggrcon
+++ b/eef.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EEF">
   <repositories enabled="false" location="https://download.eclipse.org/modeling/emft/eef/updates/releases/1.5/R201601141612/">
     <features name="org.eclipse.emf.eef.sdk-feature.feature.group" versionRange="[1.5.0,1.6.0)">

--- a/egit.aggrcon
+++ b/egit.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EGit">
   <repositories location="https://download.eclipse.org/egit/staging/v7.8.0.202607290745-m2" description="EGit Updates">
     <features name="org.eclipse.jgit.feature.group" versionRange="[7.8.0.202607290745-m2]">

--- a/embedcdt.aggrcon
+++ b/embedcdt.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Embedded CDT">
   <repositories location="https://download.eclipse.org/embed-cdt/releases/6.7.0/p2/" description="Embed CDT Updates">
     <features name="org.eclipse.embedcdt.codered.feature.group" versionRange="[6.7.0.202602251544]">

--- a/emf-compare.aggrcon
+++ b/emf-compare.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF Compare">
   <repositories location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202605071334">
     <features name="org.eclipse.emf.compare.feature.group" versionRange="[3.3.0,3.4.0)"/>

--- a/emf-services.aggrcon
+++ b/emf-services.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF Services">
   <repositories location="https://download.eclipse.org/modeling/emf/validation/updates/releases/R202605251143/" description="EMF Validation">
     <features name="org.eclipse.emf.validation.sdk.feature.group">

--- a/emf.aggrcon
+++ b/emf.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF (Core)">
   <repositories location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202607041336" description="EMF 2.47">
     <features name="org.eclipse.emf.ecore.xcore.sdk.feature.group">

--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse">
   <repositories location="https://download.eclipse.org/eclipse/updates/4.41-I-builds/I20260723-2300" description="Eclipse and Equinox">
     <products name="org.eclipse.platform.ide"/>

--- a/epp-mpc.aggrcon
+++ b/epp-mpc.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EPP Marketplace Client">
   <repositories location="https://download.eclipse.org/mpc/drops/1.13.0/v20250816-1241/" description="EPP Marketplace Client">
     <features name="org.eclipse.epp.mpc.feature.group" versionRange="[1.13.0,1.13.1)">

--- a/gef.aggrcon
+++ b/gef.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="GEF">
   <repositories location="https://download.eclipse.org/tools/gef/classic/milestone/S202607271527" description="GEF Classic releases">
     <features name="org.eclipse.draw2d.sdk.feature.group">

--- a/gmf-runtime.aggrcon
+++ b/gmf-runtime.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="GMF Runtime">
   <repositories location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202512020858" description="GMF Runtime 1.16.8rc1">
     <features name="org.eclipse.gmf.feature.group">

--- a/graphiti.aggrcon
+++ b/graphiti.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="The Eclipse Modeling Graphiti project" label="Graphiti">
   <repositories location="https://download.eclipse.org/graphiti/updates/release/0.19.4" description="Graphiti 0.19.4 Release Update Site">
     <features description="The feature containing extensions for the Graphiti framework, currently it contains only the SVG Diagram export" name="org.eclipse.graphiti.export.feature.feature.group" versionRange="[0.19.4,0.20.0)">

--- a/linuxtools.aggrcon
+++ b/linuxtools.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Linux Tools">
   <repositories location="https://download.eclipse.org/linuxtools/update-2026-09-m2" description="Linux Tools Updates">
     <features name="org.eclipse.linuxtools.cdt.libhover.devhelp.feature.feature.group" versionRange="[8.24.0.202607281720,8.24.1)">

--- a/lsp4e.aggrcon
+++ b/lsp4e.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="LSP4E">
   <repositories location="https://download.eclipse.org/lsp4e/releases/0.30.6/" description="LSP4E">
     <features name="org.eclipse.lsp4e" versionRange="[0.19.13.202607150542]">

--- a/lsp4j.aggrcon
+++ b/lsp4j.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="LSP4J">
   <repositories location="https://download.eclipse.org/lsp4j/updates/releases/1.0.0/" description="Lsp4j p2 repository">
     <features name="org.eclipse.lsp4j.sdk.feature.group" versionRange="[1.0.0.v20260209-1724]">

--- a/m2e.aggrcon
+++ b/m2e.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="m2e" label="m2e">
   <repositories location="https://download.eclipse.org/technology/m2e/releases/2.11.1" description="m2e 2.11.1">
     <features name="org.eclipse.m2e.feature.feature.group">

--- a/mat.aggrcon
+++ b/mat.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Memory Analyzer (MAT)">
   <repositories location="https://download.eclipse.org/mat/2026-06/RC2/update-site/" description="Memory Analyzer Updates">
     <features name="org.eclipse.mat.feature.feature.group">

--- a/mwe.aggrcon
+++ b/mwe.aggrcon
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMFT MWE for 2026-09">
+<?xml version="1.0" encoding="UTF-8"?>
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="MWE for 2026-09">
   <repositories location="https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S202607030623" description="MWE2 Language p2 repository">
     <features name="org.eclipse.emf.mwe2.runtime.sdk.feature.group" versionRange="[2.27.0.v20260703-0622]">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>

--- a/mylyn.aggrcon
+++ b/mylyn.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Mylyn">
   <repositories location="https://download.eclipse.org/mylyn/updates/milestone/S202607291600/" description="Mylyn 4.12.0">
     <features name="org.eclipse.mylyn.bugzilla.feature.feature.group" versionRange="[4.12.0.v20260708-1250]">

--- a/ocl.aggrcon
+++ b/ocl.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="OCL for 2026-09">
   <repositories location="https://download.eclipse.org/modeling/mdt/ocl/builds/release/6.24.0" description="OCL">
     <features name="org.eclipse.ocl.all.sdk.feature.group" versionRange="[5.24.0,5.25.0)">

--- a/papyrus.aggrcon
+++ b/papyrus.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" description="Contribution of the Modeling Papyrus project" label="Papyrus">
   <repositories location="https://download.eclipse.org/modeling/mdt/papyrus/papyrus-desktop/updates/milestones/7.0/RC2/main" description="Papyrus">
     <features description="Papyrus SDK Feature" name="org.eclipse.papyrus.sdk.feature.feature.group">

--- a/parsley.aggrcon
+++ b/parsley.aggrcon
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF Parsley">
+<?xml version="1.0" encoding="UTF-8"?>
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Parsley">
   <repositories location="https://download.eclipse.org/emf-parsley/updates/1.18/1.18.0.v20240826-1656/" description="EMF Parsley">
     <features name="org.eclipse.emf.parsley.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>

--- a/passage.aggrcon
+++ b/passage.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Passage">
   <repositories location="https://download.eclipse.org/passage/updates/milestone/S202607280816/" description="Eclipse Passage LDC 4.7.0">
     <features name="org.eclipse.passage.ldc.feature.feature.group" versionRange="[4.7.0.v20260728-0816]">

--- a/pdt.aggrcon
+++ b/pdt.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="PDT">
   <repositories location="https://download.eclipse.org/tools/pdt/updates/8.4rc2a/" description="PDT 8.4.0">
     <features name="org.eclipse.php.feature.group">

--- a/qvtd.aggrcon
+++ b/qvtd.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="QVT Declarative for 2026-09">
   <repositories location="https://download.eclipse.org/mmt/qvtd/builds/release/0.35.0" description="QVT Declarative">
     <features name="org.eclipse.qvtd.master.feature.group" versionRange="[0.35.0,1.0.0)">

--- a/qvto.aggrcon
+++ b/qvto.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="QVT Operational for 2026-09">
   <repositories location="https://download.eclipse.org/mmt/qvto/builds/milestone/S202607300728" description="QVT Operational 3.11.4 release">
     <features name="org.eclipse.m2m.qvt.oml.sdk.feature.group" versionRange="[3.11.4,3.12.0)">

--- a/rap-tools.aggrcon
+++ b/rap-tools.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="RAP Tools">
   <repositories location="https://download.eclipse.org/rt/rap/tools/4.8/M1-20260708-0640/" description="RAP 4.8 Tools Repository">
     <features name="org.eclipse.rap.tools.feature.feature.group" versionRange="[4.8.0,4.9.0)">

--- a/rcptt.aggrcon
+++ b/rcptt.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" label="RCPTT">
   <repositories location="https://download.eclipse.org/rcptt/release/2.5.4/repository/">
     <features name="org.eclipse.rcptt.platform.feature.group" versionRange="2.5.4">

--- a/scout.aggrcon
+++ b/scout.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Eclipse Scout is a framework to develop Java based business applications.&#xA;The HTML5 front-end of Scout applications comes with multi-device support and is based on HTML5/CSS3/JavaScript. This package includes a SDK, useful developer tools and source code." label="Scout">
   <repositories location="https://download.eclipse.org/scout/releases/14.0/42/" description="Scout SDK">
     <features description="Eclipse Scout SDK" name="org.eclipse.scout.sdk-feature.feature.group" versionRange="14.0.42">

--- a/simrel.aggr
+++ b/simrel.aggr
@@ -1,46 +1,47 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Aggregation files used for the Eclipse Simultaneous Release (quarterly &quot;release train&quot;)." buildmaster="//@contacts[email='ed.merks@gmail.com']" buildmasterBackup="//@contacts[email='frederic.gurr@eclipse.org']" label="2026-09" buildRoot="buildresults" packedStrategy="UNPACK_AS_SIBLING" sendmail="true" type="I" allowLegacySites="false" includeSources="true">
   <validationSets label="main">
+    <contributions href="acceleo.aggrcon#/"/>
+    <contributions href="atl.aggrcon#/"/>
     <contributions href="buildship.aggrcon#/"/>
+    <contributions href="cdo.aggrcon#/"/>
     <contributions href="cdt.aggrcon#/"/>
-    <contributions href="dltk.aggrcon#/"/>
     <contributions href="dtp.aggrcon#/"/>
+    <contributions href="dltk.aggrcon#/"/>
     <contributions href="ecf.aggrcon#/"/>
-    <contributions href="emft-eef.aggrcon#/"/>
-    <contributions href="egit.aggrcon#/"/>
-    <contributions href="emf-emf.aggrcon#/"/>
-    <contributions href="emf-cdo.aggrcon#/"/>
-    <contributions href="emf-compare.aggrcon#/"/>
-    <contributions href="emf-parsley.aggrcon#/"/>
-    <contributions href="emf-services.aggrcon#/"/>
-    <contributions href="emft-ecoretools.aggrcon#/"/>
-    <contributions href="emft-mwe.aggrcon#/"/>
-    <contributions href="epp-mpc.aggrcon#/"/>
     <contributions href="eclemma.aggrcon#/"/>
     <contributions href="ep.aggrcon#/"/>
+    <contributions href="ecoretools.aggrcon#/"/>
+    <contributions href="eef.aggrcon#/"/>
+    <contributions href="egit.aggrcon#/"/>
     <contributions href="embedcdt.aggrcon#/"/>
+    <contributions href="emf.aggrcon#/"/>
+    <contributions href="emf-compare.aggrcon#/"/>
+    <contributions href="emf-services.aggrcon#/"/>
+    <contributions href="epp-mpc.aggrcon#/"/>
     <contributions href="gef.aggrcon#/"/>
-    <contributions href="gmp-gmf-runtime.aggrcon#/"/>
-    <contributions href="gmp-graphiti.aggrcon#/"/>
+    <contributions href="gmf-runtime.aggrcon#/"/>
+    <contributions href="graphiti.aggrcon#/"/>
+    <contributions href="linuxtools.aggrcon#/"/>
     <contributions href="lsp4e.aggrcon#/"/>
     <contributions href="lsp4j.aggrcon#/"/>
-    <contributions href="linuxtools.aggrcon#/"/>
-    <contributions href="m2m-atl.aggrcon#/"/>
-    <contributions href="m2t-acceleo.aggrcon#/"/>
+    <contributions href="m2e.aggrcon#/"/>
     <contributions href="mat.aggrcon#/"/>
+    <contributions href="mwe.aggrcon#/"/>
     <contributions href="mylyn.aggrcon#/"/>
     <contributions href="ocl.aggrcon#/"/>
     <contributions href="oomph.aggrcon#/"/>
-    <contributions href="pdt.aggrcon#/"/>
-    <contributions href="mdt-papyrus.aggrcon#/"/>
+    <contributions href="papyrus.aggrcon#/"/>
+    <contributions href="parsley.aggrcon#/"/>
     <contributions href="passage.aggrcon#/"/>
+    <contributions href="pdt.aggrcon#/"/>
     <contributions href="qvtd.aggrcon#/"/>
     <contributions href="qvto.aggrcon#/"/>
     <contributions href="rap-tools.aggrcon#/"/>
     <contributions href="rcptt.aggrcon#/"/>
-    <contributions href="swtbot.aggrcon#/"/>
     <contributions href="scout.aggrcon#/"/>
     <contributions href="sirius.aggrcon#/"/>
+    <contributions href="swtbot.aggrcon#/"/>
     <contributions href="tcf.aggrcon#/"/>
     <contributions href="tm4e.aggrcon#/"/>
     <contributions href="tracecompass.aggrcon#/"/>
@@ -48,9 +49,8 @@
     <contributions href="webtools.aggrcon#/"/>
     <contributions href="wildwebdeveloper.aggrcon#/"/>
     <contributions href="windowbuilder.aggrcon#/"/>
+    <contributions href="xtext.aggrcon#/"/>
     <contributions href="xwt.aggrcon#/"/>
-    <contributions href="tmf-xtext.aggrcon#/"/>
-    <contributions href="m2e.aggrcon#/"/>
   </validationSets>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="aarch64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="ppc64le"/>
@@ -62,7 +62,7 @@
   <configurations architecture="x86_64"/>
   <customCategories identifier="Application Development Frameworks" label="Application Development Frameworks" description="Frameworks supporting application development.">
     <features href="gef.aggrcon#//@repositories.0/@features.0"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.2"/>
     <features href="gef.aggrcon#//@repositories.2/@features.0"/>
     <features href="gef.aggrcon#//@repositories.1/@features.9"/>
     <features href="gef.aggrcon#//@repositories.1/@features.10"/>
@@ -76,8 +76,8 @@
     <features href="gef.aggrcon#//@repositories.1/@features.7"/>
     <features href="gef.aggrcon#//@repositories.0/@features.1"/>
     <features href="gef.aggrcon#//@repositories.1/@features.8"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.1"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.1"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="scout.aggrcon#//@repositories.0/@features.0"/>
     <features href="ep.aggrcon#//@repositories.0/@features.15"/>
     <features href="gef.aggrcon#//@repositories.0/@features.2"/>
@@ -88,7 +88,7 @@
     <features href="ecf.aggrcon#//@repositories.0/@features.1"/>
     <features href="egit.aggrcon#//@repositories.0/@features.2"/>
     <features href="egit.aggrcon#//@repositories.0/@features.4"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.2"/>
     <features href="egit.aggrcon#//@repositories.0/@features.0"/>
     <features href="egit.aggrcon#//@repositories.0/@features.7"/>
     <features href="egit.aggrcon#//@repositories.0/@features.3"/>
@@ -117,7 +117,7 @@
     <features href="mylyn.aggrcon#//@repositories.0/@features.19"/>
     <features href="mylyn.aggrcon#//@repositories.0/@features.20"/>
     <features href="mylyn.aggrcon#//@repositories.0/@features.21"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="pdt.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>
   <customCategories identifier="Database Development" label="Database Development" description="Tools to define and access a wide variety of databases.">
@@ -157,17 +157,17 @@
     <features href="dtp.aggrcon#//@repositories.0/@features.33"/>
     <features href="dtp.aggrcon#//@repositories.0/@features.34"/>
     <features href="dtp.aggrcon#//@repositories.0/@features.35"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.1"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.1"/>
   </customCategories>
   <customCategories identifier="EclipseRT Target Platform Components" label="EclipseRT Target Platform Components" description="This category identifies various Eclipse technology that is commonly used in runtime scenarios from RCP to embedded to server side. The components in this category are intended to be added to your Target Platform, rather than your IDE.">
     <features href="ecf.aggrcon#//@repositories.0/@features.0"/>
     <features href="ecf.aggrcon#//@repositories.0/@features.1"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
-    <features href="emf-emf.aggrcon#//@repositories.0/@features.2"/>
-    <features href="emf-emf.aggrcon#//@repositories.0/@features.2"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.2"/>
+    <features href="emf.aggrcon#//@repositories.0/@features.2"/>
+    <features href="emf.aggrcon#//@repositories.0/@features.2"/>
     <features href="ep.aggrcon#//@repositories.0/@features.7"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.1"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.1"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.0"/>
   </customCategories>
   <customCategories identifier="General Purpose Tools" label="General Purpose Tools" description="Tools that can be used by a wide variety of developers.">
     <features href="buildship.aggrcon#//@repositories.0/@features.0"/>
@@ -217,7 +217,7 @@
     <features href="windowbuilder.aggrcon#//@repositories.0/@features.10"/>
     <features href="windowbuilder.aggrcon#//@repositories.0/@features.6"/>
     <features href="windowbuilder.aggrcon#//@repositories.0/@features.7"/>
-    <features href="tmf-xtext.aggrcon#//@repositories.0/@features.0"/>
+    <features href="xtext.aggrcon#//@repositories.0/@features.0"/>
     <features href="xwt.aggrcon#//@repositories.0/@features.0"/>
     <features href="xwt.aggrcon#//@repositories.0/@features.1"/>
   </customCategories>
@@ -250,54 +250,54 @@
     <features href="tcf.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>
   <customCategories identifier="Modeling" label="Modeling" description="Model definition, creation, and manipulation frameworks (e.g. EMF, OCL, GMF, M2M, M2T, GEF) and industry models (e.g. UML, JEM, XSD).">
-    <features href="m2t-acceleo.aggrcon#//@repositories.0/@features.0"/>
+    <features href="acceleo.aggrcon#//@repositories.0/@features.0"/>
     <features href="gef.aggrcon#//@repositories.0/@features.0"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.3"/>
-    <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.3"/>
+    <features href="cdo.aggrcon#//@repositories.0/@features.2"/>
     <features href="emf-compare.aggrcon#//@repositories.0/@features.4"/>
     <features href="emf-compare.aggrcon#//@repositories.0/@features.5"/>
     <features href="emf-compare.aggrcon#//@repositories.0/@features.1"/>
     <features href="emf-compare.aggrcon#//@repositories.0/@features.2"/>
-    <features href="emf-emf.aggrcon#//@repositories.0/@features.0"/>
-    <features href="emft-ecoretools.aggrcon#//@repositories.0/@features.0"/>
-    <features href="emft-eef.aggrcon#//@repositories.0/@features.1"/>
-    <features href="emft-eef.aggrcon#//@repositories.0/@features.1"/>
-    <features href="emft-eef.aggrcon#//@repositories.0/@features.0"/>
-    <features href="emft-mwe.aggrcon#//@repositories.0/@features.1"/>
-    <features href="emft-mwe.aggrcon#//@repositories.0/@features.2"/>
-    <features href="emft-mwe.aggrcon#//@repositories.0/@features.0"/>
-    <features href="emf-emf.aggrcon#//@repositories.0/@features.1"/>
-    <features href="emf-parsley.aggrcon#//@repositories.0/@features.1"/>
-    <features href="emf-parsley.aggrcon#//@repositories.0/@features.0"/>
-    <features href="emf-emf.aggrcon#//@repositories.0/@features.2"/>
+    <features href="emf.aggrcon#//@repositories.0/@features.0"/>
+    <features href="ecoretools.aggrcon#//@repositories.0/@features.0"/>
+    <features href="eef.aggrcon#//@repositories.0/@features.1"/>
+    <features href="eef.aggrcon#//@repositories.0/@features.1"/>
+    <features href="eef.aggrcon#//@repositories.0/@features.0"/>
+    <features href="mwe.aggrcon#//@repositories.0/@features.1"/>
+    <features href="mwe.aggrcon#//@repositories.0/@features.2"/>
+    <features href="mwe.aggrcon#//@repositories.0/@features.0"/>
+    <features href="emf.aggrcon#//@repositories.0/@features.1"/>
+    <features href="parsley.aggrcon#//@repositories.0/@features.1"/>
+    <features href="parsley.aggrcon#//@repositories.0/@features.0"/>
+    <features href="emf.aggrcon#//@repositories.0/@features.2"/>
     <features href="emf-services.aggrcon#//@repositories.1/@features.0"/>
     <features href="emf-services.aggrcon#//@repositories.0/@features.0"/>
     <features href="gef.aggrcon#//@repositories.0/@features.1"/>
-    <features href="gmp-gmf-runtime.aggrcon#//@repositories.0/@features.0"/>
-    <features href="gmp-gmf-runtime.aggrcon#//@repositories.1/@features.0"/>
-    <features href="gmp-gmf-runtime.aggrcon#//@repositories.0/@features.1"/>
-    <features href="gmp-graphiti.aggrcon#//@repositories.0/@features.0"/>
-    <features href="gmp-graphiti.aggrcon#//@repositories.0/@features.1"/>
-    <features href="gmp-graphiti.aggrcon#//@repositories.0/@features.2"/>
-    <features href="gmp-graphiti.aggrcon#//@repositories.0/@features.3"/>
-    <features href="gmp-graphiti.aggrcon#//@repositories.0/@features.4"/>
-    <features href="gmp-graphiti.aggrcon#//@repositories.0/@features.5"/>
-    <features href="m2m-atl.aggrcon#//@repositories.0/@features.0"/>
-    <features href="m2m-atl.aggrcon#//@repositories.0/@features.1"/>
+    <features href="gmf-runtime.aggrcon#//@repositories.0/@features.0"/>
+    <features href="gmf-runtime.aggrcon#//@repositories.1/@features.0"/>
+    <features href="gmf-runtime.aggrcon#//@repositories.0/@features.1"/>
+    <features href="graphiti.aggrcon#//@repositories.0/@features.0"/>
+    <features href="graphiti.aggrcon#//@repositories.0/@features.1"/>
+    <features href="graphiti.aggrcon#//@repositories.0/@features.2"/>
+    <features href="graphiti.aggrcon#//@repositories.0/@features.3"/>
+    <features href="graphiti.aggrcon#//@repositories.0/@features.4"/>
+    <features href="graphiti.aggrcon#//@repositories.0/@features.5"/>
+    <features href="atl.aggrcon#//@repositories.0/@features.0"/>
+    <features href="atl.aggrcon#//@repositories.0/@features.1"/>
     <features href="qvto.aggrcon#//@repositories.0/@features.0"/>
     <features href="qvto.aggrcon#//@repositories.0/@features.1"/>
     <features href="ocl.aggrcon#//@repositories.0/@features.0"/>
     <features href="ocl.aggrcon#//@repositories.0/@features.1"/>
     <features href="ocl.aggrcon#//@repositories.0/@features.2"/>
-    <features href="mdt-papyrus.aggrcon#//@repositories.0/@features.0"/>
+    <features href="papyrus.aggrcon#//@repositories.0/@features.0"/>
     <features href="qvtd.aggrcon#//@repositories.0/@features.0"/>
     <features href="sirius.aggrcon#//@repositories.0/@features.6"/>
     <features href="sirius.aggrcon#//@repositories.0/@features.2"/>
     <features href="sirius.aggrcon#//@repositories.0/@features.0"/>
     <features href="sirius.aggrcon#//@repositories.0/@features.7"/>
     <features href="uml2.aggrcon#//@repositories.0/@features.0"/>
-    <features href="emf-emf.aggrcon#//@repositories.0/@features.3"/>
-    <features href="tmf-xtext.aggrcon#//@repositories.0/@features.0"/>
+    <features href="emf.aggrcon#//@repositories.0/@features.3"/>
+    <features href="xtext.aggrcon#//@repositories.0/@features.0"/>
     <features href="gef.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>
   <customCategories identifier="Performance, Profiling and Tracing Tools" label="Performance, Profiling and Tracing Tools" description="Tools to assit analysis of running code.">
@@ -351,7 +351,7 @@
     <features href="webtools.aggrcon#//@repositories.0/@features.20"/>
     <features href="webtools.aggrcon#//@repositories.0/@features.21"/>
     <features href="webtools.aggrcon#//@repositories.0/@features.25"/>
-    <features href="tmf-xtext.aggrcon#//@repositories.0/@features.1"/>
+    <features href="xtext.aggrcon#//@repositories.0/@features.1"/>
     <features href="xwt.aggrcon#//@repositories.0/@features.0"/>
     <features href="xwt.aggrcon#//@repositories.0/@features.1"/>
   </customCategories>

--- a/simrel.aggran
+++ b/simrel.aggran
@@ -147,7 +147,7 @@
     </project>
   </contribution>
   <contribution
-      contribution="emf-emf.aggrcon#/">
+      contribution="emf.aggrcon#/">
     <tag>dsl</tag>
     <tag>modeling</tag>
     <project
@@ -322,7 +322,7 @@
   </contribution>
   <contribution
       label="Ecore Tools"
-      contribution="emft-ecoretools.aggrcon#/">
+      contribution="ecoretools.aggrcon#/">
     <tag>modeling</tag>
     <project
         name="Eclipse Ecore Tools"
@@ -337,7 +337,7 @@
   </contribution>
   <contribution
       label="ATL"
-      contribution="m2m-atl.aggrcon#/">
+      contribution="atl.aggrcon#/">
     <project
         name="Eclipse ATL"
         site="https://projects.eclipse.org/projects/modeling.atl"
@@ -362,7 +362,7 @@
   </contribution>
   <contribution
       label="MWE"
-      contribution="emft-mwe.aggrcon#/">
+      contribution="mwe.aggrcon#/">
     <tag>dsl</tag>
     <project
         name="Eclipse Modeling Workflow Engine"
@@ -555,7 +555,7 @@
     </project>
   </contribution>
   <contribution
-      contribution="emf-cdo.aggrcon#/">
+      contribution="cdo.aggrcon#/">
     <tag>modeling</tag>
     <project
         name="Eclipse CDO Model Repository"
@@ -632,7 +632,7 @@
   </contribution>
   <contribution
       label="Acceleo"
-      contribution="m2t-acceleo.aggrcon#/">
+      contribution="acceleo.aggrcon#/">
     <project
         name="Eclipse Acceleo"
         site="https://projects.eclipse.org/projects/modeling.acceleo"
@@ -645,7 +645,7 @@
   </contribution>
   <contribution
       label="GMF Runtime"
-      contribution="gmp-gmf-runtime.aggrcon#/">
+      contribution="gmf-runtime.aggrcon#/">
     <tag>modeling</tag>
     <project
         name="Eclipse GMF Runtime"
@@ -677,7 +677,7 @@
     </project>
   </contribution>
   <contribution
-      contribution="tmf-xtext.aggrcon#/">
+      contribution="xtext.aggrcon#/">
     <tag>dsl</tag>
     <project
         name="Eclipse Xtext"
@@ -702,7 +702,7 @@
     </project>
   </contribution>
   <contribution
-      contribution="emft-eef.aggrcon#/">
+      contribution="eef.aggrcon#/">
     <project
         name="Eclipse Extended Editing Framework (EEF)"
         site="https://projects.eclipse.org/projects/modeling.eef"
@@ -749,7 +749,7 @@
   </contribution>
   <contribution
       label="Graphiti"
-      contribution="gmp-graphiti.aggrcon#/">
+      contribution="graphiti.aggrcon#/">
     <project
         name="Eclipse Graphiti"
         site="https://projects.eclipse.org/projects/modeling.graphiti"
@@ -763,7 +763,7 @@
   </contribution>
   <contribution
       enabled="false"
-      contribution="mdt-papyrus.aggrcon#/">
+      contribution="papyrus.aggrcon#/">
     <project
         name="Eclipse Papyrus"
         site="https://projects.eclipse.org/projects/modeling.papyrus"
@@ -939,7 +939,7 @@
     </project>
   </contribution>
   <contribution
-      contribution="emf-parsley.aggrcon#/">
+      contribution="parsley.aggrcon#/">
     <tag>modeling</tag>
     <project
         name="Eclipse EMF Parsley"

--- a/sirius.aggrcon
+++ b/sirius.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Eclipse Sirius" label="Sirius Desktop">
   <repositories location="https://download.eclipse.org/sirius/updates/releases/7.6.0/2025-09/">
     <features name="org.eclipse.sirius.specifier.feature.group">

--- a/swtbot.aggrcon
+++ b/swtbot.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SWTBot">
   <repositories location="https://download.eclipse.org/technology/swtbot/releases/4.3.0/" description="SWTBot Contribution for 2025-12">
     <features name="org.eclipse.swtbot.ide.feature.group">

--- a/tcf.aggrcon
+++ b/tcf.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="TCF">
   <repositories location="https://download.eclipse.org/tools/tcf/releases/1.11/1.11.0" description="TCF 1.11.0">
     <features name="org.eclipse.tcf.cdt.feature.feature.group">

--- a/tm4e.aggrcon
+++ b/tm4e.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="TM4E">
   <repositories location="https://download.eclipse.org/tm4e/releases/0.17.2/" description="TextMate for Eclipse (TM4E) 0.17.2">
     <features name="org.eclipse.tm4e.feature.feature.group" versionRange="[0.17.2.202602051927]">

--- a/tracecompass.aggrcon
+++ b/tracecompass.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Trace Compass Updates" label="Trace Compass">
   <repositories location="https://download.eclipse.org/tracecompass/2026-09/milestones/m1/" description="Trace Compass Updates">
     <features name="org.eclipse.tracecompass.lttng2.control.feature.group" versionRange="0.1.0"/>

--- a/uml2.aggrcon
+++ b/uml2.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="UML2 for 2026-09">
   <repositories location="https://download.eclipse.org/modeling/mdt/uml2/builds/release/5.6.1" description="UML2">
     <features name="org.eclipse.uml2.sdk.feature.group" versionRange="[5.6.1,6.0.0)">

--- a/webtools.aggrcon
+++ b/webtools.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Web Tools Platform">
   <repositories location="https://download.eclipse.org/webtools/downloads/drops/R3.43.0/S-3.43M2-20260729032334/repository/" description="Web Tools Platform 3.43 for 2026-09">
     <bundles name="org.eclipse.wtp.epp.package.capabilities"/>

--- a/wildwebdeveloper.aggrcon
+++ b/wildwebdeveloper.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Wild Web Developer">
   <repositories location="https://download.eclipse.org/wildwebdeveloper/updates/milestone/S202607041435" description="Wild Web Developer 1.4.1">
     <features name="org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group" versionRange="[1.2.6,1.2.7)">

--- a/windowbuilder.aggrcon
+++ b/windowbuilder.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Window Builder GUI Designer" label="Window Builder">
   <repositories location="https://download.eclipse.org/windowbuilder/updates/milestone/S202607281915" description="WindowBuilder 1.25.0">
     <features name="org.eclipse.wb.core.feature.feature.group">

--- a/xtext.aggrcon
+++ b/xtext.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Xtext, Xtend">
   <repositories location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/2.44.0.M1" description="Xtext p2 repository">
     <features name="org.eclipse.xtext.sdk.feature.group" versionRange="[2.44.0.v20260707-0538]">

--- a/xwt.aggrcon
+++ b/xwt.aggrcon
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ASCII"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" description="XWT - Declarative UI in XML for Eclipse" label="XWT">
   <repositories location="https://download.eclipse.org/xwt/release-1.9.200">
     <features description="XWT Runtime" name="org.eclipse.xwt.feature.feature.group">


### PR DESCRIPTION
- Convert all to use encoding="UTF-8".
- Remove modeling container-project prefixes from file names and *.aggrcon labels, except for EMF Services and EMF Compare.
- Sort based on the simplified labels.