### PR TITLE
Remove workaround for org.eclipse.orbit.xml-apis-ext

### DIFF
--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -58,8 +58,5 @@
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
   </repositories>
-  <repositories location="https://download.eclipse.org/tools/orbit/simrel/orbit-legacy/milestone/latest">
-    <bundles name="org.eclipse.orbit.xml-apis-ext"/>
-  </repositories>
   <contacts href="simrel.aggr#//@contacts[email='rahul.mohanan@ibm.com']"/>
 </aggregator:Contribution>


### PR DESCRIPTION
- The org.eclipse.orbit.xml-apis-ext bundle  is now contributed by GMF.